### PR TITLE
fix: rounding for 2 digits instead of 3

### DIFF
--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -11,7 +11,7 @@ enum Action {
   BOUGHT = "Bought",
 }
 
-const roundValue = (value: number) => value.toFixed(3);
+const roundValue = (value: number) => value.toFixed(2);
 
 const makeMessage = async (
   sale: Sale,


### PR DESCRIPTION
this PR changes the way that the code round values. We're using INTL for better support, and decreasing the fraction digits to 2.